### PR TITLE
fix(socketproxy): add option for disabling ipv6

### DIFF
--- a/defaults/main/socketproxy.yml
+++ b/defaults/main/socketproxy.yml
@@ -3,6 +3,9 @@
 # Version of the socket-proxy Docker image to use (see 'svc_socketproxy_container_image')
 svc_socketproxy_version: v0.4.1
 
+# Whether to enable IPv6 inside the socket proxy container
+svc_socketproxy_disable_ipv6: 'true'
+
 # Settings for the docker socket proxy. See https://github.com/Tecnativa/docker-socket-proxy#grant-or-revoke-access-to-certain-api-sections
 svc_socketproxy_settings:
   LOG_LEVEL: "info"

--- a/vars/main/socketproxy.yml
+++ b/vars/main/socketproxy.yml
@@ -1,5 +1,6 @@
 ---
 # Environment variables for the docker-socket-proxy container. Required by traefik
 svc_socketproxy_env_vars_baseline:
+  DISABLE_IPV6: "{{ svc_socketproxy_disable_ipv6 }}"
   CONTAINERS: "1"
 ...


### PR DESCRIPTION
Add config option to disable IPv6 for docker-socket-proxy. Fixes issue on hosts where IPv6 is disabled